### PR TITLE
revert to SNAPSHOT version and set name and description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,11 @@
   <version>${revision}</version>
   <packaging>pom</packaging>
 
+  <name>daanse project - parent pom</name>
+  <description>This pom is the base/parent-pom for all other maven-projects of the daanse project</description>
+
   <properties>
-    <revision>0.0.1</revision>
+    <revision>0.0.1-SNAPSHOT</revision>
 
     <project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Rule "pom-staging" failures
Invalid POM: /org/eclipse/daanse/org.eclipse.daanse.pom.parent/0.0.1/ org.eclipse.daanse.pom.parent-0.0.1.pom

Project name missing,
Project description missing