### PR TITLE
Update GitHub workflow and Maven configuration for Sonatype Central

### DIFF
--- a/.github/workflows/all_stale_bot.yml
+++ b/.github/workflows/all_stale_bot.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   stale:
     uses: eclipse-daanse/.github/.github/workflows/reuse_all_stale_bot.yml@main
+    secrets:
+      envGH: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.daanse</groupId>
   <artifactId>org.eclipse.daanse.pom.parent</artifactId>
-  <version>0.0.3-SNAPSHOT</version>
+  <version>0.0.3</version>
   <packaging>pom</packaging>
 
   <name>daanse project - parent pom</name>
@@ -97,12 +97,18 @@
     <url>https://github.com/${repo.part}/issues</url>
   </issueManagement>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <repositories>
     <repository>
       <id>ossrh</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -915,6 +921,15 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -987,15 +1002,8 @@
             <artifactId>maven-gpg-plugin</artifactId>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
- Add `envGH` secret to GitHub workflow
- Update snapshot repository URL in `pom.xml`
- Add `distributionManagement` for Maven snapshots
- Replace Nexus plugin with Central publishing plugin
- Remove deprecated Nexus staging plugin configuration
- Configure `central-publishing-maven-plugin` for publishing
