### PR TITLE
Add Maven Central repository and enable auto-publishing configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
   </issueManagement>
 
   <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <name>Maven Central Repo</name>
+      <url>https://central.sonatype.com</url>
+    </repository>
     <snapshotRepository>
       <id>ossrh</id>
       <url>https://central.sonatype.com/repository/maven-snapshots</url>
@@ -928,6 +933,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
- Added `<repository>` to `distributionManagement` for Maven Central
- Updated snapshot repository URL in `distributionManagement`
- Enabled `autoPublish` in `central-publishing-maven-plugin` configuration
- Improved publishing setup for Maven Central integration
- Ensured compatibility with Sonatype repository standards
